### PR TITLE
Add context option to copy a gate's current URL

### DIFF
--- a/src/GateView.ts
+++ b/src/GateView.ts
@@ -2,7 +2,9 @@ import { ItemView, WorkspaceLeaf, Menu } from 'obsidian'
 import { createWebviewTag } from './fns/createWebviewTag'
 import { Platform } from 'obsidian'
 import { createIframe } from './fns/createIframe'
+import { clipboard } from 'electron'
 import WebviewTag = Electron.WebviewTag
+
 export class GateView extends ItemView {
     private readonly options: GateFrameOption
     private frame: WebviewTag | HTMLIFrameElement
@@ -125,6 +127,17 @@ export class GateView extends ItemView {
                 } else {
                     this.frame.openDevTools()
                 }
+            })
+        })
+        menu.addItem((item) => {
+            item.setTitle('Copy Page URL')
+            item.setIcon('clipboard-copy')
+            item.onClick(() => {
+                if (this.frame instanceof HTMLIFrameElement) {
+                    return
+                }
+
+                clipboard.writeText(this.frame.getURL())
             })
         })
     }


### PR DESCRIPTION
Add a context menu option to be able to copy the current gate URL to the clipboard. This is useful when you've navigated within a gate and need the URL of where you currently are.

![Screenshot 2023-11-30 at 2 28 55 PM](https://github.com/nguyenvanduocit/obsidian-open-gate/assets/4482878/fedee6cf-67a6-4462-aadc-d974c1658bb9)

