### PR TITLE
Fix missing gate removal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -179,6 +179,7 @@ export default class OpenGatePlugin extends Plugin {
     async removeGate(gateId: string) {
         if (!this.settings.gates[gateId]) {
             new Notice('Gate not found')
+            return
         }
 
         const gate = this.settings.gates[gateId]


### PR DESCRIPTION
## Summary
- fix `removeGate` to exit early if the gate doesn't exist

## Testing
- `npm run build` *(fails: cannot find module 'obsidian', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684162aadde4832bbe100132aba71dec