### PR TITLE
Update gate docs for CSS/JS notice

### DIFF
--- a/docs/gate-link.md
+++ b/docs/gate-link.md
@@ -10,7 +10,7 @@ This feature allows you to create a link that opens a URL within the gate view o
 
 Please notice that the URL must be encoded. You can use [this tool](https://www.urlencoder.org/) to encode your URL.
 
-You may want to read [Gate Options](gate-options.md) to learn more about the options you can use. Of course, the are no space for custom css or javascript in the gate view.
+You may want to read [Gate Options](gate-options.md) to learn more about the options you can use. Of course, there is no space for custom CSS or JavaScript in the gate view.
 
 ## Editor context menu
 

--- a/docs/gate-options.md
+++ b/docs/gate-options.md
@@ -38,4 +38,4 @@ The `zoomFactor` in the `GateFrameOption` determines the magnification level of 
 - Incorrect CSS/JS may break the appearance/functionality of the gate.
 - Be cautious with JS that interacts with external websites to avoid security risks.
 
-You may want to read [Gate Options](gate-options.md) to learn more about the options you can use. Of course, the are no space for custom css or javascript in the gate view.
+You may want to read [Gate Options](gate-options.md) to learn more about the options you can use. Of course, there is no space for custom CSS or JavaScript in the gate view.


### PR DESCRIPTION
## Summary
- clarify that there is no space for custom CSS/JavaScript in the gate view

## Testing
- `npx prettier docs/gate-link.md docs/gate-options.md -w`

------
https://chatgpt.com/codex/tasks/task_e_684163a1f080832b812452de4d2cfe4f