### PR TITLE
Add vitest config and tests for normalizeGateOption

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write .",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "test": "vitest"
   },
   "keywords": [],
   "author": "",
@@ -29,7 +30,8 @@
     "quicklink": "^2.3.0",
     "tslib": "2.4.0",
     "typescript": "4.7.4",
-    "vitepress": "^1.5.0"
+    "vitepress": "^1.5.0",
+    "vitest": "^1.0.0"
   },
   "dependencies": {
     "yaml": "^2.6.1"

--- a/tests/normalizeGateOption.test.ts
+++ b/tests/normalizeGateOption.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeGateOption } from '../src/fns/normalizeGateOption'
+import { getSvgIcon } from '../src/fns/getSvgIcon'
+
+// Helper to clone object
+const clone = <T>(obj: T): T => JSON.parse(JSON.stringify(obj))
+
+describe('normalizeGateOption', () => {
+  it('generates id when none is supplied', () => {
+    const gate = { url: 'https://example.com' }
+    const normalized = normalizeGateOption(clone(gate))
+    expect(normalized.id).toBe(btoa('https://example.com'))
+  })
+
+  it('applies default profile key and zoom factor', () => {
+    const gate = { url: 'https://example.com' }
+    const normalized = normalizeGateOption(clone(gate))
+    expect(normalized.profileKey).toBe('open-gate')
+    expect(normalized.zoomFactor).toBe(1)
+  })
+
+  it('defaults icon and title correctly', () => {
+    const url = 'https://example.com'
+    const normalized = normalizeGateOption({ url })
+    expect(normalized.icon).toBe(getSvgIcon(url))
+    expect(normalized.title).toBe(url)
+  })
+
+  it('throws error when url is missing', () => {
+    // @ts-expect-error testing missing url
+    expect(() => normalizeGateOption({})).toThrow('URL is required')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary
- set up `vitest` test runner
- add initial test for `normalizeGateOption`
- expose `npm test` script

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684163b4dcc8832bbdf7884245200682